### PR TITLE
Don't set a paddingTop for NavigationCard

### DIFF
--- a/CustomComponents/NavigationCard.js
+++ b/CustomComponents/NavigationCard.js
@@ -127,7 +127,6 @@ var styles = StyleSheet.create({
     shadowOpacity: 0.4,
     shadowOffset: {width: 0, height: 0},
     shadowRadius: 10,
-    paddingTop: 64,
     top: 0,
     bottom: 0,
     position: 'absolute',

--- a/Examples/NavigationAnimatedExample.js
+++ b/Examples/NavigationAnimatedExample.js
@@ -44,7 +44,7 @@ class NavigationAnimatedExample extends React.Component {
             renderScene={(props) => (
               <NavigationCard
                 {...props}>
-                <ScrollView>
+                <ScrollView style={styles.scrollView}>
                   <NavigationExampleRow
                     text={navState.get(navState.index)}
                   />
@@ -71,6 +71,9 @@ class NavigationAnimatedExample extends React.Component {
 const styles = StyleSheet.create({
   animatedView: {
     flex: 1,
+  },
+  scrollView: {
+    marginTop: 64
   },
 });
 

--- a/Examples/NavigationPersistenceExample.js
+++ b/Examples/NavigationPersistenceExample.js
@@ -69,7 +69,7 @@ const NavigationAnimatedExample = React.createClass({
         renderScene={(props) => (
           <NavigationCard
             {...props}>
-            <ScrollView>
+            <ScrollView style={styles.scrollView}>
               <NavigationExampleRow
                 text={navState.get(navState.index)}
               />
@@ -94,6 +94,9 @@ const NavigationAnimatedExample = React.createClass({
 const styles = StyleSheet.create({
   animatedView: {
     flex: 1,
+  },
+  scrollView: {
+    marginTop: 64
   },
 });
 


### PR DESCRIPTION
This makes it possible to use the same `NavigationCard` both with and without the header, and makes it easy to use in Android, which has a different height for header. The `marginTop` is instead set in the scene.

This will also allow the scene to scroll below a semi-transparent header.
