### PR TITLE
Animate transform instead of left/right. Fixes #8

### DIFF
--- a/CustomComponents/NavigationCard.js
+++ b/CustomComponents/NavigationCard.js
@@ -103,11 +103,15 @@ class NavigationCard extends React.Component {
         style={[
           styles.card,
           {
-            right: gestureValue,
-            left: gestureValue.interpolate({
-              inputRange: [0, 1],
-              outputRange: [0, -1],
-            }),
+            transform: [
+              {
+                translateX: gestureValue.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [0, -1],
+                }),
+              },
+            ],
+
           }
         ]}>
         {this.props.children}
@@ -128,8 +132,10 @@ var styles = StyleSheet.create({
     shadowOffset: {width: 0, height: 0},
     shadowRadius: 10,
     top: 0,
+    right: 0,
     bottom: 0,
-    position: 'absolute',
+    left: 0,
+    position: 'absolute'
   },
 });
 


### PR DESCRIPTION
It also fixes a rendering glitch on initial render. When the scene is first rendered with no width set, then changes to screen width, it has a ugly effect on initial render. It gets fixed by setting left and right properties by default.

Tested on Android.

Fixes #8
