### PR TITLE
renderOverlay optional, propTypes improvements

### DIFF
--- a/Navigation/NavigationAnimatedView.js
+++ b/Navigation/NavigationAnimatedView.js
@@ -67,6 +67,7 @@ var NavigationAnimatedView = React.createClass({
   propTypes: {
     navigationState: React.PropTypes.object.isRequired,
     renderScene: React.PropTypes.func.isRequired,
+    renderOverlay: React.PropTypes.func,
   },
   getInitialState: function() {
     return {
@@ -142,8 +143,6 @@ var NavigationAnimatedView = React.createClass({
       });
     }
 
-    console.log('BALAAA', nextScenes)
-
     nextScenes = nextScenes.sort(compareScenes);
 
     return nextScenes;
@@ -160,7 +159,7 @@ var NavigationAnimatedView = React.createClass({
         }}
         style={this.props.style}>
         {this.state.scenes.map(this._renderScene, this)}
-        {this._renderOverlay(this._renderOverlay, this)}
+        {this.props.renderOverlay && this._renderOverlay(this._renderOverlay, this)}
       </View>
     );
   },

--- a/Navigation/NavigationAnimatedView.js
+++ b/Navigation/NavigationAnimatedView.js
@@ -65,7 +65,7 @@ function compareScenes(
 
 var NavigationAnimatedView = React.createClass({
   propTypes: {
-    navigationState: React.PropTypes.object.isRequired,
+    navigationState: NavigationState.NavigationStateShape.isRequired,
     renderScene: React.PropTypes.func.isRequired,
     renderOverlay: React.PropTypes.func,
   },

--- a/Navigation/NavigationState.js
+++ b/Navigation/NavigationState.js
@@ -12,12 +12,18 @@
 'use strict';
 
 const invariant = require('invariant');
+var React = require('react-native');
 
 export type NavigationRoute = string | {
   key: string;
   index: ?number;
   routes: ?Array<NavigationRoute>;
 };
+
+export const NavigationStateShape = React.PropTypes.shape({
+  routes: React.PropTypes.array.isRequired,
+  index: React.PropTypes.number.isRequired,
+});
 
 export function getKey(navState: NavigationRoute): string {
   if (typeof navState === 'string') {
@@ -136,4 +142,3 @@ export function replaceAtIndex(navState: NavigationRoute, index: number, newRout
     routes,
   };
 }
-

--- a/Navigation/NavigationView.js
+++ b/Navigation/NavigationView.js
@@ -20,6 +20,9 @@ var {
 } = React;
 
 var NavigationView = React.createClass({
+  propTypes: {
+    navigationState: NavigationState.NavigationStateShape.isRequired,
+  },
   render: function() {
     return (
       <View


### PR DESCRIPTION
This patch 
- makes renderOverlay optional and adds the prop to propTypes (NavigationAnimatedView)
- Removes an errant console.log
- Adds NavigationState.NavigationStateShape which is a custom PropType

I am however unsure about the implementation of NavigationStateShape. Is there some way to integrate propTypes with flow types?
