### PR TITLE
Corrected link and changed title of Navigation Landscape

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -6,7 +6,7 @@ A new Navigation system for react native. Focuses on the following improvements 
 - Navigation logic and routing must be independent from view logic to allow for a variety of native and js-based navigation views
 - Improved modularity of scene animations, gestures, and navigation bars
 
-If you're confused about all the navigation options, look at the [Navigation Landscape](Docs/Navigation.md) doc.
+If you're confused about all the navigation options, look at the [Navigation Comparison](Docs/NavigationOverview.md) doc.
 
 ## Code
 


### PR DESCRIPTION
The title now corresponds to the Docs at the bottom.
